### PR TITLE
Cambiar tema a modo claro

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,12 +1,12 @@
 
 :root {
-  --bg: #111111;
-  --card: #18181b;
-  --accent: #facc15;
-  --muted: #a1a1aa;
-  --correct: #22c55e;
-  --wrong: #ef4444;
-  --border: #232323;
+  --bg: #f5f5f5;
+  --card: #ffffff;
+  --accent: #2563eb;
+  --muted: #4b5563;
+  --correct: #15803d;
+  --wrong: #dc2626;
+  --border: #e4e4e7;
 }
 
 * { box-sizing: border-box; }
@@ -15,7 +15,7 @@ body {
   margin: 0;
   font-family: 'Inter', 'Segoe UI', Arial, Helvetica, sans-serif;
   background: var(--bg);
-  color: #f4f4f5;
+  color: #1f2933;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -37,29 +37,29 @@ body {
   font-size: 1.5rem;
   font-weight: 700;
   letter-spacing: -1px;
-  color: #fff;
+  color: #0f172a;
 }
 .score {
-  background: #18181b;
+  background: #e0e7ff;
   color: var(--accent);
   padding: 0.45rem 1.1rem;
   border-radius: 999px;
   font-weight: 600;
   font-size: 1.05rem;
-  border: 1px solid var(--border);
-  box-shadow: 0 1px 4px #0002;
+  border: 1px solid #c7d2fe;
+  box-shadow: 0 8px 20px #1d4ed820;
 }
 .card {
   background: var(--card);
   border-radius: 16px;
   padding: 1.5rem 1.2rem 1.2rem 1.2rem;
-  box-shadow: 0 6px 32px #000a;
+  box-shadow: 0 18px 40px #0f172a16;
   border: 1px solid var(--border);
 }
 .question {
   font-size: 1.13rem;
   margin: 0 0 1.1rem;
-  color: #fff;
+  color: #0f172a;
   font-weight: 500;
 }
 .answers {
@@ -68,8 +68,8 @@ body {
   gap: 0.7rem;
 }
 .answer {
-  background: #18181b;
-  color: #f4f4f5;
+  background: #f8fafc;
+  color: #1f2937;
   border: 1.5px solid var(--border);
   padding: 0.85rem 0.7rem;
   border-radius: 10px;
@@ -78,10 +78,10 @@ body {
   text-align: left;
   font-size: 1rem;
   font-weight: 500;
-  box-shadow: 0 1px 4px #0002;
+  box-shadow: 0 10px 20px #0f172a12;
 }
 .answer:hover:not(:disabled) {
-  background: #232323;
+  background: #e2e8f0;
   transform: translateY(-2px) scale(1.03);
   border-color: var(--accent);
 }
@@ -89,12 +89,12 @@ body {
   outline: 2px solid var(--accent);
 }
 .answer.correct {
-  background: linear-gradient(90deg, rgba(34,197,94,0.13), rgba(34,197,94,0.07));
+  background: linear-gradient(90deg, rgba(21,128,61,0.12), rgba(21,128,61,0.05));
   border-color: var(--correct);
   color: var(--correct);
 }
 .answer.wrong {
-  background: linear-gradient(90deg, rgba(239,68,68,0.13), rgba(239,68,68,0.07));
+  background: linear-gradient(90deg, rgba(220,38,38,0.12), rgba(220,38,38,0.05));
   border-color: var(--wrong);
   color: var(--wrong);
 }
@@ -119,7 +119,7 @@ body {
   border: none;
   padding: 0.6rem 0.9rem;
   border-radius: 8px;
-  color: #18181b;
+  color: #f8fafc;
   cursor: pointer;
   font-weight: 600;
   font-size: 1rem;


### PR DESCRIPTION
## Summary
- actualizar la paleta de colores global para emplear tonos claros y contraste adecuado
- ajustar estilos de tarjetas, botones y respuestas para el nuevo tema claro con sombras suaves

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ca62903fa88330b0848bb0819543f3